### PR TITLE
correct typo in docker.mdc

### DIFF
--- a/.cursor/rules/docker.mdc
+++ b/.cursor/rules/docker.mdc
@@ -1,5 +1,5 @@
 ---
-description: when docekr is mentioned or related. 
+description: when docker is mentioned or related.
 globs: 
 alwaysApply: false
 ---


### PR DESCRIPTION
Typo in description for docker cursor rule